### PR TITLE
Fix testNegativeChangeName

### DIFF
--- a/src/test/java/iteration2/ChangeNameTest.java
+++ b/src/test/java/iteration2/ChangeNameTest.java
@@ -24,7 +24,7 @@ public class ChangeNameTest {
 
     public String getCurrentUserName(long userId) {
         GetProfileResponse response = new ValidatedCrudRequester<GetProfileResponse>(RequestSpecs.authAsUser(userRequest.getUsername(), userRequest.getPassword()), Endpoint.GET_PROFILE, ResponseSpecs.requestReturnsOK()).get(0);
-        return response.getUsername();
+        return response.getName();
     }
 
     @BeforeEach


### PR DESCRIPTION
Fix `getCurrentUserName` in `ChangeNameTest` to return the profile's display name instead of the username.

The `testNegativeChangeName` was failing because the helper method `getCurrentUserName` was returning the `username` field, while the test intended to validate changes to the `name` (display name) field. This change aligns the helper with the field being tested.

---
<a href="https://cursor.com/background-agent?bcId=bc-155cf45e-0d85-433c-8581-8e848ebe0728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-155cf45e-0d85-433c-8581-8e848ebe0728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

