### PR TITLE
Fix json parsing error in change name test

### DIFF
--- a/src/test/java/iteration2/ChangeNameTest.java
+++ b/src/test/java/iteration2/ChangeNameTest.java
@@ -6,7 +6,9 @@ import models.UpdateProfileRequest;
 import models.UpdateProfileResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.apache.http.HttpStatus;
 import requests.skelethon.Endpoint;
 import requests.skelethon.requesters.CrudRequester;
 import requests.skelethon.requesters.ValidatedCrudRequester;
@@ -47,6 +49,22 @@ public class ChangeNameTest {
         // Проверяем, что имя в профиле обновилось
         assertEquals(newName, response.getCustomer().getName(), "Имя пользователя не обновилось корректно");
         assertEquals("Profile updated successfully", response.getMessage(), "Сообщение об обновлении профиля не совпадает");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    public void testNegativeChangeName(String invalidName) {
+        UpdateProfileRequest updateProfileRequest = UpdateProfileRequest.builder().name(invalidName).build();
+
+        new CrudRequester(
+                RequestSpecs.authAsUser(userRequest.getUsername(), userRequest.getPassword()),
+                Endpoint.UPDATE_PROFILE,
+                ResponseSpecs.requestReturnsBadRequestWithoutKeyWithOutValue()
+        )
+        .put(updateProfileRequest)
+        .assertThat()
+        .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 
 


### PR DESCRIPTION
Add a negative test for changing a user's name to prevent JSON parsing of non-JSON error responses.

---
<a href="https://cursor.com/background-agent?bcId=bc-84b2d9f4-6c9c-45d5-8864-a9b13103e74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84b2d9f4-6c9c-45d5-8864-a9b13103e74e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

